### PR TITLE
Added proper save and reraise

### DIFF
--- a/repoze/tm/__init__.py
+++ b/repoze/tm/__init__.py
@@ -26,15 +26,12 @@ class TM:
                 yield chunk
         except Exception:
             """Saving the exception"""
-            type_, value, tb = sys.exc_info()
-            self.abort()
-            raise type_, value, tb
-        #try:
-        #    for chunk in self.application(environ, save_status_and_headers):
-        #        yield chunk
-        #except Exception as e:
-        #    self.abort()
-        #    raise e
+            try:
+                type_, value, tb = sys.exc_info()
+                self.abort()
+                raise type_, value, tb
+            finally:
+                del type_, value, tb
 
         # ZODB 3.8 + has isDoomed
         if hasattr(transaction, 'isDoomed') and transaction.isDoomed():


### PR DESCRIPTION
This fix is based off of [similar code in OpenStack](https://github.com/openstack/oslo-incubator/blob/55b35226cf027100248ddcb11d8a7186c1635ddf/openstack/common/excutils.py)

The error I was receiving was the following:
Traceback (most recent call last):
  File "openstack/quantum/.venv/local/lib/python2.7/site-packages/eventlet/wsgi.py", line 394, in handle_one_response
    for data in result:
  File "openstack/quantum/repoze.tm2/repoze/tm/**init**.py", line 28, in **call**
    raise
TypeError: exceptions must be old-style classes or derived from BaseException, not NoneType

This was hiding the original exception and was causing serious issues. The logic behind this is that the exception was being lost during the self.abort and the reraise. Saving it now prevents the loss of the exception.
