### PR TITLE
WSGI middleware should call "close" on iterable if available

### DIFF
--- a/repoze/tm/__init__.py
+++ b/repoze/tm/__init__.py
@@ -36,7 +36,7 @@ class TM:
         self.application = application
         self.commit_veto = commit_veto
         self.transaction = transaction # for testing
-        
+
     def __call__(self, environ, start_response):
         transaction = self.transaction
         environ[ekey] = True
@@ -47,8 +47,10 @@ class TM:
             ctx.update(status=status, headers=headers)
             return start_response(status, headers, exc_info)
 
+        iterable = None
         try:
-            for chunk in self.application(environ, save_status_and_headers):
+            iterable = self.application(environ, save_status_and_headers)
+            for chunk in iterable:
                 yield chunk
         except Exception:
             """Saving the exception"""
@@ -58,6 +60,18 @@ class TM:
                 reraise(type_, value, tb)
             finally:
                 del type_, value, tb
+        finally:
+            if hasattr(iterable, 'close'):
+                try:
+                    iterable.close()
+                except Exception:
+                    """Saving the exception"""
+                    try:
+                        type_, value, tb = sys.exc_info()
+                        self.abort()
+                        reraise(type_, value, tb)
+                    finally:
+                        del type_, value, tb
 
         # ZODB 3.8 + has isDoomed
         if hasattr(transaction, 'isDoomed') and transaction.isDoomed():


### PR DESCRIPTION
This was causing issues with our instrumentation.

It wasn't 100% clear to me how to handle `close` raising an exception, so I think there's a chance that `abort` might be called twice.