### PR TITLE
Close iterable after iteration

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,3 +106,4 @@ Contributors
 - Tres Seaver, 2011/02/22
 - Stéphane Klein <stephane@harobed.org>, 2011/06/18
 - Brian Sutherland, 2011/07/11
+- Mike Milner <milner@blissisland.ca>, 2017-03-21


### PR DESCRIPTION
If the response iterator has a `.close()` method call it after iteration
is complete.

This is required by the WSGI specification, details can be found here:
https://www.python.org/dev/peps/pep-0333/#specification-details

Same idea as https://github.com/repoze/repoze.tm2/pull/6 but I moved the `.close()` call inside the outer try/except. This means the iterable will be closed() before the transaction is aborted on error. I'm not 100% sure this maintains the requirements for aborting, but this works well to solve my problem using WSGI middlewares that rely on `close()` being called.